### PR TITLE
docs: set correct cordemirror link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## Overview
 
-MirrorMark is a simple, yet extensible Markdown editor created with [Codemirror](http://www.codemirror.net). 
+MirrorMark is a simple, yet extensible Markdown editor created with [Codemirror](http://codemirror.net).
 
 See [Demo](http://musicbed.github.io/MirrorMark/).
 


### PR DESCRIPTION
The link to codemirror included a `www`, but this subdomain is not set, which results in an error.